### PR TITLE
Update to Spark 2.1.0, use Alpine-based OpenJDK, add Minikube deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Deploy Spark on Kubernetes
 
-* Spark 2.0.1
+* Spark 2.1.0
 * Hadoop 2.7.3
 
 ## Kubernetes
@@ -22,6 +22,19 @@ kubectl proxy --port=8001
 ```
 
 At which point the UI will be available at [http://localhost:8001/api/v1/proxy/namespaces/spark-cluster/services/spark-webui/](http://localhost:8001/api/v1/proxy/namespaces/spark-cluster/services/spark-webui/)
+
+## Minikube
+
+The minikube deployment is different in that it required the Web UI service to use a NodePort
+
+```
+minikube start
+kubectl create -f kubernetes/namespace-spark.yaml
+kubectl --namespace spark-cluster create -f kubernetes/minikube.yaml
+minikube service spark-webui --namespace spark-cluster
+```
+
+This will open a browser window with the Spark UI
 
 ### Example
 
@@ -46,22 +59,20 @@ word_counts = text_file \
 print word_counts.collect()
 ```
 
-
-
 ## Docker
 
 The Docker images is available on Docker Hub. To pull the image, run:
 
 ```
-docker pull ramhiser/spark:2.0.1
+docker pull ramhiser/spark:2.1.0
 ```
 
 The image was build with the following:
 
 ```
 cd docker
-docker build -t ramhiser/spark:2.0.1 .
-docker push ramhiser/spark:2.0.1
+docker build -t ramhiser/spark:2.1.0 .
+docker push ramhiser/spark:2.1.0
 ```
 
 Plagiarized from

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,9 @@
-FROM java:openjdk-8-jdk
+FROM openjdk:8u121-jre-alpine
 
 ENV hadoop_ver 2.7.3
-ENV spark_ver 2.0.1
+ENV spark_ver 2.1.0
+
+RUN apk add --no-cache curl py-numpy procps ncurses bash
 
 # Get Hadoop from US Apache mirror and extract just the native
 # libs. (Until we care about running HDFS with these containers, this
@@ -20,13 +22,6 @@ RUN mkdir -p /opt && \
         tar -zx && \
     ln -s spark-${spark_ver}-bin-hadoop2.7 spark && \
     echo Spark ${spark_ver} installed in /opt
-
-# if numpy is installed on a driver it needs to be installed on all
-# workers, so install it everywhere
-RUN apt-get update && \
-    apt-get install -y python-numpy && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
 
 ADD common.sh spark-master spark-worker /
 ADD spark-defaults.conf /opt/spark/conf/spark-defaults.conf

--- a/kubernetes/minikube.yaml
+++ b/kubernetes/minikube.yaml
@@ -43,6 +43,7 @@ apiVersion: v1
 metadata:
   name: spark-webui
 spec:
+  type: NodePort
   ports:
     - port: 8080
       targetPort: 8080


### PR DESCRIPTION
- Docker image goes from 882 MB to 505 MB
- Updated to Spark 2.1.0
- Added Minikube deployment since it requires for the UI service to be of type `NodePort`
- Updated README to reflect all these changes